### PR TITLE
Fix restart benchmark

### DIFF
--- a/src/module_benchmark_core.f90
+++ b/src/module_benchmark_core.f90
@@ -39,7 +39,6 @@ module module_benchmark_core
 		
 		FILE_NAME = "./output/lesrst_restart.nc"
 		call check(nf90_open_par(FILE_NAME, IOR(NF90_NOWRITE, NF90_MPIIO), MPI_COMM_WORLD, MPI_INFO_NULL, ncid_read))
-		call check(nf90_set_fill(ncid_read, nf90_nofill, oldmode))
 		
 		! Get the varid of the data variable, based on its name.
 		! -- ATM --

--- a/src/module_benchmark_core.f90
+++ b/src/module_benchmark_core.f90
@@ -52,7 +52,7 @@ module module_benchmark_core
 		! -- SFC --
 		call check(nf90_inq_varid(ncid_read, "tsfc", varid_read_tsfc))
 		call check(nf90_inq_varid(ncid_read, "tg1D", varid_read_tg1D))
-		call check(nf90_inq_varid(ncid_read, "raincnv", varid_read_rainncv))
+		call check(nf90_inq_varid(ncid_read, "rainncv", varid_read_rainncv))
 		call check(nf90_inq_varid(ncid_read, "rainncv_int", varid_read_rainncv_int))
 		
 		! -- SOIL --


### PR DESCRIPTION
Restart (Read) で nf90_set_fill がエラーになる問題の修正と，変数名に typo があったので修正しています．nf90_set_fill は Write mode で利用可能な関数 [^1] だと思います．いずれも #1 をベースにした PR になります．

[^1]: https://docs.unidata.ucar.edu/netcdf-fortran/current/f90_datasets.html#f90-nf90_set_fill